### PR TITLE
feat: add page transition wrapper

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -5,6 +5,7 @@ import { BottomNavbar } from "@/components/ui/bottom-navbar";
 import { Footer } from "@/components/ui/footer";
 import { CustomCursor } from "@/components/ui/custom-cursor";
 import { ScrollProgress } from "@/components/ui/scroll-progress";
+import { PageTransition } from "@/components/ui/page-transition";
 import "./globals.css";
 
 const navigationItems = [
@@ -23,7 +24,7 @@ export default function RootLayout({
       <body className="bg-[#faf9f7] cursor-none">
         <ScrollProgress />
         <main className="flex min-h-screen flex-col items-center justify-between pt-8 pb-16 md:pb-8">
-          {children}
+          <PageTransition>{children}</PageTransition>
           <FloatingNavbar items={navigationItems} />
           <BottomNavbar />
           <Footer />

--- a/src/components/ui/page-transition.tsx
+++ b/src/components/ui/page-transition.tsx
@@ -1,0 +1,22 @@
+"use client";
+
+import { usePathname } from "next/navigation";
+import { AnimatePresence, motion } from "framer-motion";
+
+export function PageTransition({ children }: { children: React.ReactNode }) {
+  const pathname = usePathname();
+  return (
+    <AnimatePresence mode="wait">
+      <motion.div
+        key={pathname}
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        exit={{ opacity: 0, y: -20 }}
+        transition={{ duration: 0.2 }}
+      >
+        {children}
+      </motion.div>
+    </AnimatePresence>
+  );
+}
+


### PR DESCRIPTION
## Summary
- add PageTransition component to animate route changes
- wrap layout children with PageTransition for smooth transitions

## Testing
- `npx biome lint src/app/layout.tsx src/components/ui/page-transition.tsx`
- `npx tsc --noEmit` *(fails: Could not find a declaration file for module 'nodemailer'; onDateSelect prop mismatch; missing logo modules)*

------
https://chatgpt.com/codex/tasks/task_e_6898f14cc7948330b42fb285d578393f